### PR TITLE
Add view model pattern to accessory views.

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -12,7 +12,7 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  DBProfileViewController: 68a16d93d03ba8d8b5055e88273e4f2f9a0755cb
+  DBProfileViewController: 8d76b1916321cc46f348b97f72b8b96c710577c2
   FXBlurView: db786c2561cb49a09ae98407f52460096ab8a44f
 
 COCOAPODS: 0.39.0

--- a/Source/DBProfileAccessoryViewLayoutAttributes.h
+++ b/Source/DBProfileAccessoryViewLayoutAttributes.h
@@ -15,6 +15,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface DBProfileAccessoryViewLayoutAttributes : NSObject
 
++ (NSArray<NSString *> *)keyPathsForBindings;
+
 /**
  *  Creates and returns a layout attributes object that represents the specified accessory view kind.
  *

--- a/Source/DBProfileAccessoryViewLayoutAttributes.m
+++ b/Source/DBProfileAccessoryViewLayoutAttributes.m
@@ -11,6 +11,11 @@
 
 @implementation DBProfileAccessoryViewLayoutAttributes
 
++ (NSArray<NSString *> *)keyPathsForBindings
+{
+    return nil;
+}
+
 + (instancetype)layoutAttributesForAccessoryViewOfKind:(NSString *)accessoryViewKind
 {
     DBProfileAccessoryViewLayoutAttributes *layoutAttributes = [[[self class] alloc] initWithAccessoryViewKind:accessoryViewKind];

--- a/Source/DBProfileAccessoryViewModel.h
+++ b/Source/DBProfileAccessoryViewModel.h
@@ -8,22 +8,39 @@
 
 #import <Foundation/Foundation.h>
 
+@class DBProfileAccessoryViewModel;
 @class DBProfileAccessoryView;
 @class DBProfileAccessoryViewLayoutAttributes;
+@class DBProfileLayoutAttributeBinding;
 
 NS_ASSUME_NONNULL_BEGIN
 
+@protocol DBProfileAccessoryViewModelUpdating <NSObject>
+
+- (void)updateLayoutAttributeFromValue:(id)fromValue toValue:(id)toValue forAccessoryViewModel:(DBProfileAccessoryViewModel *)viewModel;
+
+@end
+
 @interface DBProfileAccessoryViewModel : NSObject
 
-- (instancetype)initWithAccessoryView:(DBProfileAccessoryView *)accessoryView layoutAttributes:(DBProfileAccessoryViewLayoutAttributes *)layoutAttributes NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithAccessoryView:(DBProfileAccessoryView *)accessoryView
+                     layoutAttributes:(DBProfileAccessoryViewLayoutAttributes *)layoutAttributes NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)init NS_UNAVAILABLE;
+
+@property (nonatomic, weak) id<DBProfileAccessoryViewModelUpdating> updater;
 
 @property (nonatomic, readonly) NSString *representedAccessoryKind;
 
 @property (nonatomic, readonly) DBProfileAccessoryView *accessoryView;
 
 @property (nonatomic, readonly) DBProfileAccessoryViewLayoutAttributes *layoutAttributes;
+
+@property (nonatomic, readonly) NSArray<DBProfileLayoutAttributeBinding *> *bindings;
+
+- (void)addBinding:(DBProfileLayoutAttributeBinding *)binding;
+
+- (void)addBindings:(NSArray<DBProfileLayoutAttributeBinding *> *)bindings;
 
 @end
 

--- a/Source/DBProfileAccessoryViewModel.m
+++ b/Source/DBProfileAccessoryViewModel.m
@@ -9,16 +9,29 @@
 #import "DBProfileAccessoryViewModel.h"
 #import "DBProfileAccessoryView.h"
 #import "DBProfileAccessoryViewLayoutAttributes.h"
+#import "DBProfileLayoutAttributeBinding.h"
+
+@interface DBProfileAccessoryViewModel () <DBProfileLayoutAttributeBindingDelegate>
+
+@property (nonatomic) NSArray<DBProfileLayoutAttributeBinding *> *bindings;
+
+@end
 
 @implementation DBProfileAccessoryViewModel
 
-- (instancetype)initWithAccessoryView:(DBProfileAccessoryView *)accessoryView layoutAttributes:(DBProfileAccessoryViewLayoutAttributes *)layoutAttributes {
+- (instancetype)initWithAccessoryView:(DBProfileAccessoryView *)accessoryView
+                     layoutAttributes:(DBProfileAccessoryViewLayoutAttributes *)layoutAttributes {
     self = [super init];
     if (self) {
         _accessoryView = accessoryView;
         _layoutAttributes = layoutAttributes;
     }
     return self;
+}
+
+- (void)dealloc
+{
+    [self unbind];
 }
 
 - (NSString *)representedAccessoryKind {
@@ -31,6 +44,44 @@
     if (![object isKindOfClass:[self class]]) return NO;
     DBProfileAccessoryViewModel *otherObject = (DBProfileAccessoryViewModel *)object;
     return self.representedAccessoryKind == otherObject.representedAccessoryKind;
+}
+
+#pragma mark - Binding
+
+- (void)addBinding:(DBProfileLayoutAttributeBinding *)binding
+{
+    [self addBindings:@[binding]];
+}
+
+- (void)addBindings:(NSArray<DBProfileLayoutAttributeBinding *> *)bindings
+{
+    NSMutableArray *mutableBindings = [self.bindings mutableCopy] ?: [NSMutableArray array];
+    [mutableBindings addObjectsFromArray:bindings];
+    self.bindings = mutableBindings;
+    [self bind];
+}
+
+- (void)bind
+{
+    for (DBProfileLayoutAttributeBinding *binding in self.bindings) {
+        [binding bind];
+    }
+}
+
+- (void)unbind
+{
+    for (DBProfileLayoutAttributeBinding *binding in self.bindings) {
+        [binding unbind];
+    }
+}
+
+#pragma mark - DBProfileLayoutAttributeBindingDelegate
+
+- (void)binding:(DBProfileLayoutAttributeBinding *)binding valueDidChange:(id)newValue fromValue:(id)oldValue
+{
+    if ([self.updater respondsToSelector:@selector(updateLayoutAttributeFromValue:toValue:forAccessoryViewModel:)]) {
+        [self.updater updateLayoutAttributeFromValue:oldValue toValue:newValue forAccessoryViewModel:self];
+    }
 }
 
 @end

--- a/Source/DBProfileAccessoryViewModel.m
+++ b/Source/DBProfileAccessoryViewModel.m
@@ -29,7 +29,9 @@
         // Add bindings for layout attributes
         NSArray *keyPaths = [[layoutAttributes class] keyPathsForBindings];
         for (NSString *keyPath in keyPaths) {
-            [self addBinding:[DBProfileLayoutAttributeBinding bindingWithObject:layoutAttributes keyPath:keyPath]];
+            [self addBinding:[DBProfileLayoutAttributeBinding bindingWithObject:layoutAttributes
+                                                                        keyPath:keyPath
+                                                                       delegate:self]];
         }
     }
     return self;

--- a/Source/DBProfileAccessoryViewModel.m
+++ b/Source/DBProfileAccessoryViewModel.m
@@ -25,6 +25,12 @@
     if (self) {
         _accessoryView = accessoryView;
         _layoutAttributes = layoutAttributes;
+        
+        // Add bindings for layout attributes
+        NSArray *keyPaths = [[layoutAttributes class] keyPathsForBindings];
+        for (NSString *keyPath in keyPaths) {
+            [self addBinding:[DBProfileLayoutAttributeBinding bindingWithObject:layoutAttributes keyPath:keyPath]];
+        }
     }
     return self;
 }

--- a/Source/DBProfileAvatarViewLayoutAttributes.m
+++ b/Source/DBProfileAvatarViewLayoutAttributes.m
@@ -11,6 +11,12 @@
 
 @implementation DBProfileAvatarViewLayoutAttributes
 
++ (NSArray<NSString *> *)keyPathsForBindings
+{
+    return @[NSStringFromSelector(@selector(avatarAlignment)),
+             NSStringFromSelector(@selector(edgeInsets))];
+}
+
 - (instancetype)initWithAccessoryViewKind:(NSString *)accessoryViewKind
 {
     self = [super initWithAccessoryViewKind:accessoryViewKind];

--- a/Source/DBProfileHeaderViewLayoutAttributes.h
+++ b/Source/DBProfileHeaderViewLayoutAttributes.h
@@ -60,9 +60,9 @@ typedef NS_OPTIONS(NSUInteger, DBProfileHeaderScrollEffects) {
 @property (nonatomic) DBProfileHeaderStyle headerStyle;
 
 /**
- *  The options to apply to the associated header view.
+ *  The scroll effects to apply to the associated header view.
  *
- *  Defaults to `DBProfileHeaderOptionStretch`
+ *  Defaults to `DBProfileHeaderScrollEffectStretch`
  */
 @property (nonatomic) DBProfileHeaderScrollEffects scrollEffects;
 

--- a/Source/DBProfileHeaderViewLayoutAttributes.m
+++ b/Source/DBProfileHeaderViewLayoutAttributes.m
@@ -14,7 +14,7 @@
 + (NSArray<NSString *> *)keyPathsForBindings
 {
     return @[NSStringFromSelector(@selector(headerStyle)),
-             NSStringFromSelector(@selector(headerOptions))];
+             NSStringFromSelector(@selector(scrollEffects))];
 }
 
 - (instancetype)initWithAccessoryViewKind:(NSString *)accessoryViewKind

--- a/Source/DBProfileHeaderViewLayoutAttributes.m
+++ b/Source/DBProfileHeaderViewLayoutAttributes.m
@@ -11,6 +11,12 @@
 
 @implementation DBProfileHeaderViewLayoutAttributes
 
++ (NSArray<NSString *> *)keyPathsForBindings
+{
+    return @[NSStringFromSelector(@selector(headerStyle)),
+             NSStringFromSelector(@selector(headerOptions))];
+}
+
 - (instancetype)initWithAccessoryViewKind:(NSString *)accessoryViewKind
 {
     self = [super initWithAccessoryViewKind:accessoryViewKind];

--- a/Source/DBProfileLayoutAttributeBinding.h
+++ b/Source/DBProfileLayoutAttributeBinding.h
@@ -1,0 +1,39 @@
+//
+//  DBProfileLayoutAttributeBinding.h
+//  DBProfileViewController
+//
+//  Created by Devon Boyer on 2016-05-08.
+//  Copyright (c) 2015 Devon Boyer. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@class DBProfileLayoutAttributeBinding;
+
+@protocol DBProfileLayoutAttributeBindingDelegate <NSObject>
+
+@optional
+
+- (void)binding:(DBProfileLayoutAttributeBinding *)binding valueDidChange:(id)newValue fromValue:(id)oldValue;
+
+@end
+
+@interface DBProfileLayoutAttributeBinding : NSObject
+
+- (instancetype)initWithObject:(NSObject *)object keyPath:(NSString *)keyPath;
+
+@property (nonatomic, weak) id<DBProfileLayoutAttributeBindingDelegate> delegate;
+
+@property (nonatomic, readonly) NSObject *object;
+
+@property (nonatomic, copy, readonly) NSString *keyPath;
+
+@property (nonatomic, readonly, getter=isBound) BOOL bound;
+
+- (id)value;
+
+- (void)bind;
+
+- (void)unbind;
+
+@end

--- a/Source/DBProfileLayoutAttributeBinding.h
+++ b/Source/DBProfileLayoutAttributeBinding.h
@@ -20,9 +20,10 @@
 
 @interface DBProfileLayoutAttributeBinding : NSObject
 
-+ (instancetype)bindingWithObject:(NSObject *)object keyPath:(NSString *)keyPath;
++ (instancetype)bindingWithObject:(NSObject *)object keyPath:(NSString *)keyPath delegate:(id<DBProfileLayoutAttributeBindingDelegate>)delegate;
 
-- (instancetype)initWithObject:(NSObject *)object keyPath:(NSString *)keyPath;
+- (instancetype)initWithObject:(NSObject *)object keyPath:(NSString *)keyPath delegate:(id<DBProfileLayoutAttributeBindingDelegate>)delegate;
+
 
 @property (nonatomic, weak) id<DBProfileLayoutAttributeBindingDelegate> delegate;
 

--- a/Source/DBProfileLayoutAttributeBinding.h
+++ b/Source/DBProfileLayoutAttributeBinding.h
@@ -20,6 +20,8 @@
 
 @interface DBProfileLayoutAttributeBinding : NSObject
 
++ (instancetype)bindingWithObject:(NSObject *)object keyPath:(NSString *)keyPath;
+
 - (instancetype)initWithObject:(NSObject *)object keyPath:(NSString *)keyPath;
 
 @property (nonatomic, weak) id<DBProfileLayoutAttributeBindingDelegate> delegate;

--- a/Source/DBProfileLayoutAttributeBinding.m
+++ b/Source/DBProfileLayoutAttributeBinding.m
@@ -12,6 +12,11 @@ static void * DBProfileLayoutAttributeBindingContext = &DBProfileLayoutAttribute
 
 @implementation DBProfileLayoutAttributeBinding
 
++ (instancetype)bindingWithObject:(NSObject *)object keyPath:(NSString *)keyPath
+{
+    return [[self alloc] initWithObject:object keyPath:keyPath];
+}
+
 - (instancetype)initWithObject:(NSObject *)object keyPath:(NSString *)keyPath
 {
     self = [super init];

--- a/Source/DBProfileLayoutAttributeBinding.m
+++ b/Source/DBProfileLayoutAttributeBinding.m
@@ -12,17 +12,18 @@ static void * DBProfileLayoutAttributeBindingContext = &DBProfileLayoutAttribute
 
 @implementation DBProfileLayoutAttributeBinding
 
-+ (instancetype)bindingWithObject:(NSObject *)object keyPath:(NSString *)keyPath
++ (instancetype)bindingWithObject:(NSObject *)object keyPath:(NSString *)keyPath delegate:(id<DBProfileLayoutAttributeBindingDelegate>)delegate
 {
-    return [[self alloc] initWithObject:object keyPath:keyPath];
+    return [[self alloc] initWithObject:object keyPath:keyPath delegate:delegate];
 }
 
-- (instancetype)initWithObject:(NSObject *)object keyPath:(NSString *)keyPath
+- (instancetype)initWithObject:(NSObject *)object keyPath:(NSString *)keyPath delegate:(id<DBProfileLayoutAttributeBindingDelegate>)delegate
 {
     self = [super init];
     if (self) {
         _object = object;
         _keyPath = [keyPath copy];
+        _delegate = delegate;
     }
     return self;
 }

--- a/Source/DBProfileLayoutAttributeBinding.m
+++ b/Source/DBProfileLayoutAttributeBinding.m
@@ -1,0 +1,80 @@
+//
+//  DBProfileLayoutAttributeBinding.m
+//  DBProfileViewController
+//
+//  Created by Devon Boyer on 2016-05-08.
+//  Copyright (c) 2015 Devon Boyer. All rights reserved.
+//
+
+#import "DBProfileLayoutAttributeBinding.h"
+
+static void * DBProfileLayoutAttributeBindingContext = &DBProfileLayoutAttributeBindingContext;
+
+@implementation DBProfileLayoutAttributeBinding
+
+- (instancetype)initWithObject:(NSObject *)object keyPath:(NSString *)keyPath
+{
+    self = [super init];
+    if (self) {
+        _object = object;
+        _keyPath = [keyPath copy];
+    }
+    return self;
+}
+
+- (void)dealloc
+{
+    if (self.isBound) {
+        [self unbind];
+    }
+}
+
+#pragma mark - KVO
+
+- (id)value
+{
+    return [self.object valueForKeyPath:self.keyPath];
+}
+
+- (void)bind
+{
+    if (!self.isBound) {
+        [self.object addObserver:self
+                      forKeyPath:self.keyPath
+                         options:(NSKeyValueObservingOptionInitial | NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld)
+                         context:&DBProfileLayoutAttributeBindingContext];
+
+        _bound = YES;
+    }
+}
+
+- (void)unbind
+{
+    if (self.isBound) {
+        [self.object removeObserver:self forKeyPath:self.keyPath context:&DBProfileLayoutAttributeBindingContext];
+        _bound = NO;
+    }
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
+{
+    if (context != DBProfileLayoutAttributeBindingContext || object != self.object || ![keyPath isEqual:self.keyPath]) {
+        return;
+    }
+    
+    id newValue = change[NSKeyValueChangeNewKey];
+    if (newValue == [NSNull null]) {
+        newValue = nil;
+    }
+    
+    id oldValue = change[NSKeyValueChangeOldKey];
+    if (oldValue == [NSNull null]) {
+        oldValue = nil;
+    }
+    
+    if ([self.delegate respondsToSelector:@selector(binding:valueDidChange:fromValue:)]) {
+        [self.delegate binding:self valueDidChange:newValue fromValue:oldValue];
+    }
+}
+
+@end

--- a/Source/DBProfileViewController+DBProfileAccessoryViewModelUpdating.h
+++ b/Source/DBProfileViewController+DBProfileAccessoryViewModelUpdating.h
@@ -1,0 +1,14 @@
+//
+//  DBProfileViewController+DBProfileAccessoryViewModelUpdating.h
+//  DBProfileViewController
+//
+//  Created by Devon Boyer on 2016-05-08.
+//  Copyright (c) 2015 Devon Boyer. All rights reserved.
+//
+
+#import <DBProfileViewController/DBProfileViewController.h>
+#import <DBProfileViewController/DBProfileAccessoryViewModel.h>
+
+@interface DBProfileViewController (DBProfileAccessoryViewModelUpdating) <DBProfileAccessoryViewModelUpdating>
+
+@end

--- a/Source/DBProfileViewController+DBProfileAccessoryViewModelUpdating.m
+++ b/Source/DBProfileViewController+DBProfileAccessoryViewModelUpdating.m
@@ -1,0 +1,22 @@
+//
+//  DBProfileViewController+DBProfileAccessoryViewModelUpdating.m
+//  DBProfileViewController
+//
+//  Created by Devon Boyer on 2016-05-08.
+//  Copyright (c) 2015 Devon Boyer. All rights reserved.
+//
+
+#import "DBProfileViewController+DBProfileAccessoryViewModelUpdating.h"
+
+@implementation DBProfileViewController (DBProfileAccessoryViewModelUpdating)
+
+- (void)updateLayoutAttributeFromValue:(id)fromValue
+                               toValue:(id)toValue
+                 forAccessoryViewModel:(DBProfileAccessoryViewModel *)viewModel
+{
+    // FIXME: Ideally we only need to invalidate the specific attribute that was updated
+    // Considering using an invalidation context to specify which atttributes need updating
+    [self invalidateLayoutAttributesForAccessoryViewOfKind:viewModel.representedAccessoryKind];
+}
+
+@end

--- a/Source/DBProfileViewController+DBProfileAccessoryViewModelUpdating.m
+++ b/Source/DBProfileViewController+DBProfileAccessoryViewModelUpdating.m
@@ -14,9 +14,12 @@
                                toValue:(id)toValue
                  forAccessoryViewModel:(DBProfileAccessoryViewModel *)viewModel
 {
-    // FIXME: Ideally we only need to invalidate the specific attribute that was updated
-    // Considering using an invalidation context to specify which atttributes need updating
-    [self invalidateLayoutAttributesForAccessoryViewOfKind:viewModel.representedAccessoryKind];
+    // We don't want to try to invalidate layout attributes until the view has appeared.
+    if (_viewHasAppeared) {
+        // FIXME: Ideally we only need to invalidate the specific attribute that was updated
+        // Considering using an invalidation context to specify which atttributes need updating
+        [self invalidateLayoutAttributesForAccessoryViewOfKind:viewModel.representedAccessoryKind];
+    }
 }
 
 @end

--- a/Source/DBProfileViewController.h
+++ b/Source/DBProfileViewController.h
@@ -43,7 +43,10 @@ FOUNDATION_EXPORT NSString * const DBProfileAccessoryKindHeader;
  *
  *  This class manages and displays a collection of content controllers and customizable accessory views associated with a profile interface.
  */
-@interface DBProfileViewController : UIViewController
+@interface DBProfileViewController : UIViewController {
+@protected
+    BOOL _viewHasAppeared;
+}
 
 /**
  *  @name Creating Profile View Controllers

--- a/Source/DBProfileViewController.h
+++ b/Source/DBProfileViewController.h
@@ -153,8 +153,6 @@ FOUNDATION_EXPORT NSString * const DBProfileAccessoryKindHeader;
 /*!
  *  Invalidates the current layout attributes and triggers a layout update.
  *
- *  If any layout attributes are changed after `viewWillAppear:` is called, then this method must be called to trigger an appropriate layout update.
- *
  *  @param accessoryViewKind A string that identifies the type of the accessory view.
  */
 - (void)invalidateLayoutAttributesForAccessoryViewOfKind:(NSString *)accessoryViewKind;

--- a/Source/DBProfileViewController.m
+++ b/Source/DBProfileViewController.m
@@ -17,6 +17,8 @@
 #import "UIBarButtonItem+DBProfileViewController.h"
 #import "NSBundle+DBProfileViewController.h"
 
+#import "DBProfileViewController+DBProfileAccessoryViewModelUpdating.h"
+
 NSString * const DBProfileAccessoryKindAvatar = @"DBProfileAccessoryKindAvatar";
 NSString * const DBProfileAccessoryKindHeader = @"DBProfileAccessoryKindHeader";
 
@@ -1093,6 +1095,8 @@ static const CGFloat DBProfileViewControllerPullToRefreshTriggerDistance = 80.0;
     DBProfileAccessoryViewLayoutAttributes *layoutAttributes = [layoutAttributesClass layoutAttributesForAccessoryViewOfKind:accessoryViewKind];
     
     DBProfileAccessoryViewModel *viewModel = [[DBProfileAccessoryViewModel alloc] initWithAccessoryView:accessoryView layoutAttributes:layoutAttributes];
+    
+    viewModel.updater = self;
     
     if ([self.accessoryViewModels containsObject:viewModel]) {
         [self.accessoryViewModels removeObjectIdenticalTo:viewModel];

--- a/Source/DBProfileViewController.m
+++ b/Source/DBProfileViewController.m
@@ -46,7 +46,6 @@ static const CGFloat DBProfileViewControllerPullToRefreshTriggerDistance = 80.0;
 @property (nonatomic) NSUInteger indexForDisplayedContentController;
 @property (nonatomic) CGPoint contentOffsetForDisplayedContentController;
 @property (nonatomic, getter=isRefreshing) BOOL refreshing;
-@property (nonatomic) BOOL viewHasAppeared;
 
 // Updates
 @property (nonatomic) DBProfileViewControllerUpdateContext *updateContext;
@@ -163,7 +162,7 @@ static const CGFloat DBProfileViewControllerPullToRefreshTriggerDistance = 80.0;
     // to prevent this since we are managing the scrollView contentInset manually.
     self.automaticallyAdjustsScrollViewInsets = !showOverlayView;
     
-    if (!self.viewHasAppeared) {
+    if (!_viewHasAppeared) {
         [self reloadData];
         
         [self.view setNeedsUpdateConstraints];
@@ -182,7 +181,7 @@ static const CGFloat DBProfileViewControllerPullToRefreshTriggerDistance = 80.0;
 
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
-    self.viewHasAppeared = YES;
+    _viewHasAppeared = YES;
 }
 
 - (void)viewWillDisappear:(BOOL)animated {


### PR DESCRIPTION
Added `DBProfileLayoutAttributeBinding` and updated `DBProfileAccessoryViewModel` to include support for bindings.

There should be no need to explicitly call `invalidateLayoutAttributesForAccessoryViewOfKind:` anymore when a layout attribute is changed.
